### PR TITLE
shorten release instructions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,13 +36,11 @@ The `develop` branch is the development branch which means it contains the next 
 6. Translations: Update the `.pot` file by running `npm run makepot`.
 7. New files: Check to be sure any new files/paths that are unnecessary in the production version are included in `.gitattributes`.
 8. Merge: Make a non-fast-forward merge from your release branch to `develop` (or merge the pull request), then do the same for `develop` into `master` (`git checkout master && git merge --no-ff develop`).  `master` contains the stable development version.
-9. Build: In the `master` branch, run `npm install && npm run release`. This will create a subfolder called `release` with the latest changes copied over.
-10. Check: Are there any modified files in `master`? If so, head back to `develop`, run all necessary tasks and commit those changes before heading back to Step 6.
-11. Test: Switch to running Ad Refresh Control from the version in the `release` subfolder and run through a few common tasks in the UI to ensure functionality.
-12. Push: Push your `master` branch to GitHub (e.g. `git push origin master`).
-13. Release: Create a [new release](/releases/new), naming the tag and the release with the new version number, and targeting the `master` branch.  Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the milestone (e.g. `https://github.com/10up/ad-refresh-control/milestone/#?closed=1`).
-14. Version bump (again): In the `develop` branch (`cd ../ && git checkout develop`) bump the version number in `ad-refresh-control.php`, `ad-refresh-contorl.pot`, `composer.json`, `package.json`, and `readme.txt` to `X.Y.(Z+1)-dev`.  It's okay if the next release might be a different version number; that change can be handled right before release in the first step, as might also be the case with `@since` annotations.
-15. SVN: Wait for the [GitHub Action](/actions) to finish deploying to the WordPress.org repository.  If all goes well, users with SVN commit access for that plugin will receive an emailed diff of changes.
-16. Check WordPress.org: Ensure that the changes are live on https://wordpress.org/plugins/ad-refresh-control/. This may take a few minutes.
-17. Close milestone: Edit the [X.Y.Z milestone](/milestone/#) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description` field), then close the milestone.
-18. Punt incomplete items: If any open issues or PRs which were milestoned for `X.Y.Z` do not make it into the release, update their milestone to `X.Y.Z+1`, `X.Y+1.0`, `X+1.0.0` or `Future Release`.
+9. Test: While still on the `master` branch, test for functionality locally.
+10. Push: Push your `master` branch to GitHub (e.g. `git push origin master`).
+11. Release: Create a [new release](/releases/new), naming the tag and the release with the new version number, and targeting the `master` branch.  Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the closed issues on the milestone (e.g. `https://github.com/10up/ad-refresh-control/milestone/#?closed=1`).
+12. Version bump (again): In the `develop` branch (`cd ../ && git checkout develop`) bump the version number in `ad-refresh-control.php`, `ad-refresh-contorl.pot`, `composer.json`, `package.json`, and `readme.txt` to `X.Y.(Z+1)-dev`.  It's okay if the next release might be a different version number; that change can be handled right before release in the first step, as might also be the case with `@since` annotations.
+13. SVN: Wait for the [GitHub Action](/actions) to finish deploying to the WordPress.org repository.  If all goes well, users with SVN commit access for that plugin will receive an emailed diff of changes.
+14. Check WordPress.org: Ensure that the changes are live on https://wordpress.org/plugins/ad-refresh-control/. This may take a few minutes.
+15. Close milestone: Edit the [X.Y.Z milestone](/milestone/#) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description` field), then close the milestone.
+16. Punt incomplete items: If any open issues or PRs which were milestoned for `X.Y.Z` do not make it into the release, update their milestone to `X.Y.Z+1`, `X.Y+1.0`, `X+1.0.0` or `Future Release`.


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

When working to get 1.0.0 released, it was realized that the release instructions originally added were probably more involved than necessary.  This PR attempts to shorten them, though we'll want to ensure any build steps needed are included for the release versions.

### Alternate Designs

Keep as-is.

### Benefits

Helps eliminate confusion for new contributors assisting in the release process.

### Possible Drawbacks

None identified.

### Verification Process

Manually verified via the GitHub web UI.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
```
## Changed
- Documentation updates
```