### PR TITLE
Fix saving disable_refresh setting

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -180,7 +180,7 @@ function register_settings() {
 function sanitize_settings( $settings ) {
 
 	// disable_refresh
-	if ( isset( $settings['disable_refresh'] ) ) {
+	if ( isset( $settings['disable_refresh'] ) && filter_var( $settings['disable_refresh'], FILTER_VALIDATE_BOOLEAN ) ) {
 		$settings['disable_refresh'] = true;
 	} else {
 		$settings['disable_refresh'] = false;


### PR DESCRIPTION
The `sanitize_settings()` function is called twice when the option does not already exist. Related WordPress core trac ticket: https://core.trac.wordpress.org/ticket/21989

The current validation for the `disable_refresh` setting then causes the setting to always be updated to `false` if the setting has never been saved before. This update adds an additional check that explicitly verifies if the setting is truthy before saving the `disable_refresh` setting as `true`.

