### PR TITLE
Add exclusion for UsingCustomConstant phpcs rule

### DIFF
--- a/ad-refresh-control.php
+++ b/ad-refresh-control.php
@@ -22,7 +22,7 @@ define( 'AD_REFRESH_CONTROL_URL', plugin_dir_url( __FILE__ ) );
 define( 'AD_REFRESH_CONTROL_PATH', plugin_dir_path( __FILE__ ) );
 define( 'AD_REFRESH_CONTROL_INC', AD_REFRESH_CONTROL_PATH . 'includes/' );
 
-// Include files.
+// phpcs:disable WordPressVIPMinimum.Files.IncludingFile.UsingCustomConstant
 require_once AD_REFRESH_CONTROL_INC . 'functions/core.php';
 require_once AD_REFRESH_CONTROL_INC . 'settings.php';
 


### PR DESCRIPTION
Including files using a constant triggers a warning when using the WordPressVIPMinimum codesniffer rules.

This probably only applies to sites using the plugin on the VIP hosting platform, but it's a pesky warning that the wpcomvip-vipgoci-bot likes to flag so might as well stop it making an unneeded fuss.