### PR TITLE
Feature / Issue 46 Add Filter for Refresh Interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ add_filter( 'avc_refresh_interval_value', 'my_filter_callback', 10, 1 );
  *
  * @param  int $interval The interval value to filter on.
  *
- * @return int The refresh interval, fitlered or not.
+ * @return int The refresh interval, filtered or not.
  */
 function my_filter_callback( $interval ) {
 	$interval = 45;

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A settings page will allow adjustments such as the time between refreshes, the m
 ### Hooks
 
 ####`avc_refresh_interval_value` 
-- Filters the default refresh interval value of 30 seconds. This hook is applied to the value at storage and retrieval phases.
+- Filters the default refresh interval value of 30 seconds. This filter is applied to the value at storage and retrieval phases.
 - Since 1.0.5
 
 **Usage:**

--- a/README.md
+++ b/README.md
@@ -38,6 +38,31 @@ A settings page will allow adjustments such as the time between refreshes, the m
 
 - **Slot IDs to Exclude:** Prevent ad refreshes for specific slot IDs in the format of a comma separated list based on the ID of the div, e.g. div-gpt-ad-grid-1.
 
+### Hooks
+
+####`avc_refresh_interval_value` 
+- Filters the default refresh interval value of 30 seconds. This hook is applied to the value at storage and retrieval phases.
+- Since 1.0.5
+
+**Usage:**
+
+```
+add_filter( 'avc_refresh_interval_value', 'my_filter_callback', 10, 1 );
+
+/**
+ * Filter refresh interval to 45 seconds.
+ *
+ * @param  int $interval The interval value to filter on.
+ *
+ * @return int The refresh interval, fitlered or not.
+ */
+function my_filter_callback( $interval ) {
+	$interval = 45;
+	
+	return $interval;
+}
+```
+
 ## Support Level
 
 **Active:** 10up is actively working on this, and we expect to continue work for the foreseeable future including keeping tested up to the most recent version of WordPress.  Bug reports, feature requests, questions, and pull requests are welcome.

--- a/ad-refresh-control.php
+++ b/ad-refresh-control.php
@@ -17,7 +17,7 @@
  */
 
 // Useful global constants.
-define( 'AD_REFRESH_CONTROL_VERSION', '1.0.4' );
+define( 'AD_REFRESH_CONTROL_VERSION', '1.0.5' );
 define( 'AD_REFRESH_CONTROL_URL', plugin_dir_url( __FILE__ ) );
 define( 'AD_REFRESH_CONTROL_PATH', plugin_dir_path( __FILE__ ) );
 define( 'AD_REFRESH_CONTROL_INC', AD_REFRESH_CONTROL_PATH . 'includes/' );

--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -146,7 +146,6 @@ function scripts() {
 	 * @link  https://github.com/10up/Ad-Refresh-Control/issues/46
 	 *
 	 * @param int $refresh_interval The refresh interval in seconds. Defaults to 30.
-	 *
 	 */
 	$refresh_interval      = absint( apply_filters( 'avc_refresh_interval_value', $refresh_interval ) );
 	$maximum_refreshes     = $avc_settings['maximum_refreshes'] ?? 10;

--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -135,6 +135,20 @@ function scripts() {
 
 	$viewability_threshold = $avc_settings['viewability_threshold'] ?? 70;
 	$refresh_interval      = $avc_settings['refresh_interval'] ?? 30;
+	/**
+	 * Refresh interval.
+	 *
+	 * Allows developers to filter the default refresh interval value of 30 seconds.
+	 * We strongly advise developers to not filter this to a value less than 30 seconds.
+	 * Filterable via the avc_refresh_interval_value filter hook.
+	 *
+	 * @since 1.0.5
+	 * @link  https://github.com/10up/Ad-Refresh-Control/issues/46
+	 *
+	 * @param int $refresh_interval The refresh interval in seconds. Defaults to 30.
+	 *
+	 */
+	$refresh_interval      = absint( apply_filters( 'avc_refresh_interval_value', $refresh_interval ) );
 	$maximum_refreshes     = $avc_settings['maximum_refreshes'] ?? 10;
 
 	if ( $disable_refresh ) {

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -128,7 +128,6 @@ function refresh_interval_callback() {
 	 * @link  https://github.com/10up/Ad-Refresh-Control/issues/46
 	 *
 	 * @param int $value The refresh interval in seconds. Defaults to 30.
-	 *
 	 */
 	$value        = absint( apply_filters( 'avc_refresh_interval_value', $value ) );
 
@@ -268,7 +267,6 @@ function sanitize_settings( $settings ) {
 	 * @link  https://github.com/10up/Ad-Refresh-Control/issues/46
 	 *
 	 * @param int $refresh_interval_default The refresh interval in seconds. Defaults to 30.
-	 *
 	 */
 	$refresh_interval_default = 30;
 	$refresh_interval_default = absint( apply_filters( 'avc_refresh_interval_value', $refresh_interval_default ) );

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -117,10 +117,24 @@ function refresh_interval_callback() {
 
 	$avc_settings = get_option( 'avc_settings' );
 	$value        = $avc_settings['refresh_interval'] ?? 30;
+	/**
+	 * Refresh interval.
+	 *
+	 * Allows developers to filter the default refresh interval value of 30 seconds.
+	 * We strongly advise developers to not filter this to a value less than 30 seconds.
+	 * Filterable via the avc_refresh_interval_value filter hook.
+	 *
+	 * @since 1.0.5
+	 * @link  https://github.com/10up/Ad-Refresh-Control/issues/46
+	 *
+	 * @param int $value The refresh interval in seconds. Defaults to 30.
+	 *
+	 */
+	$value        = absint( apply_filters( 'avc_refresh_interval_value', $value ) );
 
 	?>
 		<label><input type="text" value="<?php echo esc_attr( $value ); ?>" name="avc_settings[refresh_interval]">
-			<p><?php esc_html_e( 'The number of seconds that must pass between an ad crossing the viewability threshold and the the ad refreshing. The plugin enforces a minimum of 30 in order to avoid your site being flagged for abusing ad refreshes by advertisers.', 'ad-refresh-control' ); ?></p>
+			<p><?php esc_html_e( 'The number of seconds that must pass between an ad crossing the viewability threshold and the the ad refreshing. The plugin enforces a minimum of 30 in order to avoid your site being flagged for abusing ad refreshes by advertisers. This value may however be overridden via the avc_refresh_interval_value filter hook.', 'ad-refresh-control' ); ?></p>
 		</label>
 	<?php
 }
@@ -243,8 +257,22 @@ function sanitize_settings( $settings ) {
 		$settings['viewability_threshold'] = $viewability_threshold_default;
 	}
 
-	// refresh_interval
+	/**
+	 * Refresh interval.
+	 *
+	 * Allows developers to filter the default refresh interval value of 30 seconds.
+	 * We strongly advise developers to not filter this to a value less than 30 seconds.
+	 * Filterable via the avc_refresh_interval_value filter hook.
+	 *
+	 * @since 1.0.5
+	 * @link  https://github.com/10up/Ad-Refresh-Control/issues/46
+	 *
+	 * @param int $refresh_interval_default The refresh interval in seconds. Defaults to 30.
+	 *
+	 */
 	$refresh_interval_default = 30;
+	$refresh_interval_default = absint( apply_filters( 'avc_refresh_interval_value', $refresh_interval_default ) );
+
 	if ( isset( $settings['refresh_interval'] ) ) {
 		if ( ! is_numeric( $settings['refresh_interval'] ) || intval( $settings['refresh_interval'] ) < 30 ) {
 			$settings['refresh_interval'] = intval( $refresh_interval_default );


### PR DESCRIPTION
### Description of the Change

This pull request addresses the issue at https://github.com/10up/Ad-Refresh-Control/issues/46 by introducing the application of a filter that can be used to hook into and alter the default ad refresh interval value of 30 seconds.

The filter name is `avc_refresh_interval_value` and it accepts a single argument (int) being the default filter value, or the already filtered value.

Example usage of the filter:

```
add_filter( 'avc_refresh_interval_value', 'my_filter_callback', 10, 1 );

/**
 * Filter refresh interval to 45 seconds.
 *
 * @param  int $interval The interval value to filter on.
 *
 * @return int The refresh interval, filtered or not.
 */
function my_filter_callback( $interval ) {
	$interval = 45;
	
	return $interval;
}
```

### Benefits

The benefits of this change are as follows:

1. The code addresses the issue at https://github.com/10up/Ad-Refresh-Control/issues/46
2. The code allows developers/publishers to filter in an ad refresh value that can not be changed by way of the settings screen, thus hardening the value for instances where the refresh value is vital to the objectives of the business, or where the value - for whatever reason - needs to be set to a value less than 30 seconds.  

### Possible Drawbacks

- If a developer has filtered in a value and the publisher needs to override the value via the WordPress settings screen, they will not be able to as the filtered value will always supersede all other values.
-  
### Verification Process

- Cleared the wp_options table of options stored against the `avc_settings` key.
- Added a filter in the themes functions.php file to set the refresh interval value to 50 seconds.
- Validated that even prior to saving, the refresh interval was 50.
- Validated that even prior to saving, running `AdRefreshControl.refreshInterval` in console produced the filtered value.
- Validated that after saving, the refresh value was still 50.
- Validated that after saving, running `AdRefreshControl.refreshInterval` in the console produced the filtered value.
- Validated that regardless of the value passed to the settings field, the stored and retrieved value was always 50.

The filter applied for testing was as follows:

```
add_filter( 'avc_refresh_interval_value', 'my_filter_callback', 10, 1 );

/**
 * Filter refresh interval to 45 seconds.
 *
 * @param  int $interval The interval value to filter on.
 *
 * @return int The refresh interval, filtered or not.
 */
function my_filter_callback( $interval ) {
	$interval = 45;
	
	return $interval;
}
```

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

https://github.com/10up/Ad-Refresh-Control/issues/46 

### Changelog Entry

## [1.0.5] - 2021-06-10
### Added
- `avc_refresh_interval_value` filter applied to default refresh interval value of 30 seconds (props [@10upsimon](https://github.com/10upsimon) via [#48](https://github.com/10up/Ad-Refresh-Control/pull/48)).

