### PR TITLE
Check if value was already converted from comma separated strings to …

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -294,7 +294,11 @@ function sanitize_settings( $settings ) {
 	$advertiser_ids_default = [];
 	if ( ! empty( $settings['advertiser_ids'] ) ) {
 
-		$advertiser_ids = explode( ',', $settings['advertiser_ids'] );
+		if ( is_array( $settings['advertiser_ids'] ) ) {
+			$advertiser_ids = $settings['advertiser_ids'];
+		} else {
+			$advertiser_ids = explode( ',', $settings['advertiser_ids'] );
+		}
 
 		$advertiser_ids = array_filter(
 			$advertiser_ids,
@@ -318,7 +322,11 @@ function sanitize_settings( $settings ) {
 	$line_item_ids_default = [];
 	if ( ! empty( $settings['line_item_ids'] ) ) {
 
-		$line_item_ids = explode( ',', $settings['line_item_ids'] );
+		if ( is_array( $settings['line_item_ids'] ) ) {
+			$line_item_ids = $settings['line_item_ids'];
+		} else {
+			$line_item_ids = explode( ',', $settings['line_item_ids'] );
+		}
 
 		$line_item_ids = array_filter(
 			$line_item_ids,
@@ -351,7 +359,11 @@ function sanitize_settings( $settings ) {
 	$slot_ids_to_exclude_default = [];
 	if ( ! empty( $settings['slot_ids_to_exclude'] ) ) {
 
-		$slot_ids_to_exclude = explode( ',', $settings['slot_ids_to_exclude'] );
+		if ( is_array( $settings['slot_ids_to_exclude'] ) ) {
+			$slot_ids_to_exclude = $settings['slot_ids_to_exclude'];
+		} else {
+			$slot_ids_to_exclude = explode( ',', $settings['slot_ids_to_exclude'] );
+		}
 
 		$slot_ids_to_exclude = array_filter(
 			$slot_ids_to_exclude,


### PR DESCRIPTION
### Description of the Change

When the plugin settings are saved for the first time, `sanitize_settings` is called twice:
1. At the moment of submitting the form
2. At the moment of adding new option because it was not exist before

During the second call, the option is already sanitized and comma separated strings from "Excluded Advertiser IDs", "Line Items IDs to Exclude" or "Slot IDs to Exclude" setting fields was converted to arrays.

In this case, the `explode` function fails with Fatal Error in PHP 8.

https://github.com/10up/Ad-Refresh-Control/blob/5a47af029f4c4cfbef2be76feafc353cc236446c/includes/settings.php#L297

This PR is checking if the option was already sanitized before using `explode`.

Closes #65 

### Verification Process

Reproduce steps from the issue report, there should be no Fatal Error in PHP 8 or Warning in PHP 7.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

Fixed - Error when saving settings for the first time of using the plugin

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @cadic
