### PR TITLE
Bump WordPress "tested up to" version 6.4 on `trunk`

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      10up, doomwaxer, davidrgreen, jeffpaul
 Tags:              google, ad manager
 Requires at least: 5.7
-Tested up to:      6.3
+Tested up to:      6.4
 Requires PHP:      7.4
 Stable tag:        1.1.3
 License:           GPLv2 or later


### PR DESCRIPTION
Ports #134 to `trunk` to hopefully trigger the Readme action and push the update to WP.org.