### PR TITLE
Add support for the WordPress.org plugin preview

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,0 +1,26 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "\/wp-admin\/options-general.php?page=ad-refresh-control-settings",
+	"preferredVersions": {
+		"php": "7.4",
+		"wp": "latest"
+	},
+	"phpExtensionBundles": ["kitchen-sink"],
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin",
+			"password": "password"
+		},
+		{
+			"step": "installPlugin",
+			"pluginZipFile": {
+				"resource": "wordpress.org\/plugins",
+				"slug": "ad-refresh-control"
+			},
+			"options": {
+				"activate": true
+			}
+		}
+	]
+}


### PR DESCRIPTION
### Description of the Change

WordPress.org recently launched support for plugin previews utilizing the WordPress Playground feature. Plugins wanting to take advantage of this need to opt in by setting up a `blueprint.json` file that configures how the preview should load. This PR adds in that file that does the following:

1. Sets up an environment running PHP 7.4 (our supported minimum) and the latest version of WordPress
2. Logs into the admin
3. Installs and activates the Ad Refresh Control plugin
4. Sends the user to the Ads Refresh Control settings page

Note that this PR is targeted to `trunk` as the hope is we can take advantage of our Plugin Asset Update Action to deploy these changes without having to push out a new release. This new blueprint file needs to live within the `assets` directory in the svn repo, which is the same directory that Action will send changes to.

Also note once these changes are on .org, the preview button will need to be enabled in a test state. Once verified as working, we can enable it for all users.

### How to test the Change

The WordPress Playground allows you to spin up a new environment directly through the URL, by going to `https://playground.wordpress.net/#` and pasting your JSON config after the `#`. In this case, the URL should be: https://playground.wordpress.net/#{%22$schema%22:%22https://playground.wordpress.net/blueprint-schema.json%22,%22landingPage%22:%22/wp-admin/options-general.php?page=ad-refresh-control-settings%22,%22preferredVersions%22:{%22php%22:%227.4%22,%22wp%22:%22latest%22},%22phpExtensionBundles%22:[%22kitchen-sink%22],%22steps%22:[{%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22},{%22step%22:%22installPlugin%22,%22pluginZipFile%22:{%22resource%22:%22wordpress.org/plugins%22,%22slug%22:%22ad-refresh-control%22},%22options%22:{%22activate%22:true}}]}

### Changelog Entry

> Added - Support for the WordPress.org plugin preview

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
