### PR TITLE
Fix: trim whitespace from slot ID exclusions to prevent space-padded …

### DIFF
--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -130,7 +130,7 @@ function scripts() {
 	);
 	$slot_ids_to_exclude_assoc = [];
 	foreach ( $slot_ids_to_exclude as $slot_id ) {
-		$slot_ids_to_exclude_assoc[ trim( $slot_id) ] = 1;
+		$slot_ids_to_exclude_assoc[ trim( $slot_id ) ] = 1;
 	}
 
 	$viewability_threshold = $avc_settings['viewability_threshold'] ?? 70;

--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -130,7 +130,7 @@ function scripts() {
 	);
 	$slot_ids_to_exclude_assoc = [];
 	foreach ( $slot_ids_to_exclude as $slot_id ) {
-		$slot_ids_to_exclude_assoc[ $slot_id ] = 1;
+		$slot_ids_to_exclude_assoc[ trim( $slot_id) ] = 1;
 	}
 
 	$viewability_threshold = $avc_settings['viewability_threshold'] ?? 70;

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -213,8 +213,15 @@ function slot_ids_to_exclude_callback() {
 	$avc_settings = get_option( 'avc_settings' );
 	$value        = $avc_settings['slot_ids_to_exclude'] ?? [];
 
+	$value = array_filter(
+		array_map(
+			'trim',
+			$value
+		),
+		'strlen'
+	);
 	?>
-		<label><input type="text" value="<?php echo esc_attr( implode( ',', $value ) ); ?>" name="avc_settings[slot_ids_to_exclude]">
+		<label><input type="text" value="<?php echo esc_attr( implode( ', ', $value ) ); ?>" name="avc_settings[slot_ids_to_exclude]">
 			<p><?php esc_html_e( 'Prevent ad refreshes for specific slot IDs e.g. div-gpt-ad-grid-1. (Comma-separated list).', 'ad-refresh-control' ); ?></p>
 		</label>
 	<?php
@@ -373,7 +380,7 @@ function sanitize_settings( $settings ) {
 		);
 		$slot_ids_to_exclude = array_map(
 			function ( $slot_id ) {
-				return (string) $slot_id;
+				return (string) trim( $slot_id );
 			},
 			$slot_ids_to_exclude
 		);


### PR DESCRIPTION
…entries from failing to match


### Description of the Change
When a comma-separated list of slot IDs is entered in the plugin settings with spaces after commas (e.g. `ad--youtube1x1, ad-youtube1x1`), the whitespace is preserved when building the `$slot_ids_to_exclude_assoc` array. This causes the serialized JavaScript object to contain space-padded keys (e.g. `" ad-youtube1x1"`) that will never match a real slot element ID, silently breaking the exclusion for those slots.

The fix adds `trim()` to each slot ID as it's added to the associative array, consistent with how `sizes_to_exclude` already handles whitespace via `array_map`/`trim()`.

### How to test the Change
1. In the plugin settings, add slot IDs to the exclusion list with spaces after commas,  e.g. `div-gpt-ad-123, div-gpt-ad-456`
2. View page source and inspect the `AdRefreshControl` JS object
3. Confirm that slot ID keys in `slotIdsToExclude` are trimmed and match the actual slot element IDs on the page
4. Confirm those slots do not refresh

### Changelog Entry
Fixed - Trim whitespace from slot ID exclusion list entries to prevent space-padded keys from failing to match slot element IDs

### Credits
Props @trrill

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).

