### PR TITLE
Replace deprecated `${var}` with `{$var}`.

### DIFF
--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -75,7 +75,7 @@ function deactivate() {
  * @return string|WP_Error URL
  */
 function script_url( $script ) {
-	return AD_REFRESH_CONTROL_URL . "dist/js/${script}.js";
+	return AD_REFRESH_CONTROL_URL . "dist/js/{$script}.js";
 }
 
 /**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Fixes a PHP deprecation warning `PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /vagrant/content/plugins/ad-refresh-control/includes/functions/core.php on line 78`

Closes https://github.com/10up/Ad-Refresh-Control/issues/182

### How to test the Change

1. Activate plugin
2. Activate test plugin included in `tests/test-plugin/e2e-test-plugin.php`
3. Enable `WP_DEBUG` and `WP_DEBUG_DISPLAY` in your wp-config file
4. Ensure deprecation message is not shown when visiting the front end of the site.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - PHP deprecation message: `Using ${var} in strings is deprecated...`

### Credits
Props @peterwilsoncc, @blloyd78.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
